### PR TITLE
Avoid modifying state after component unmount

### DIFF
--- a/machine.js
+++ b/machine.js
@@ -17,9 +17,13 @@ export function createUseMachine(useEffect, useState) {
     let [machine, setMachine] = useState(providedMachine);
     let [service, setService] = useState(runInterpreter);
 
+    let mounted = true;
     function runInterpreter(arg) {
       let m = arg || machine;
       return interpret(m, service => {
+        if (!mounted) {
+          return;
+        }
         setCurrent(createCurrent(service.child || service));
       });
     }
@@ -33,6 +37,9 @@ export function createUseMachine(useEffect, useState) {
         let newService = runInterpreter(providedMachine);
         setService(newService);
         setCurrent(createCurrent(newService));
+      }
+      return () => {
+        mounted = false;
       }
     }, [providedMachine]);
 


### PR DESCRIPTION
I'm curious to hear suggestions on a better way to deal with state transitions that result in a component unmounting.  As a side effect of a state change, I'd like to navigate to a new URL that will cause a component using my machine to unmount.  This results in warnings from React about updating a component state after unmount (see https://github.com/matthewp/react-robot/issues/9).

I don't have any immediate ideas about how to add a test for this.  I also understand if this is not the direction you want to go.