### PR TITLE
Pass along initial context

### DIFF
--- a/machine.js
+++ b/machine.js
@@ -13,15 +13,15 @@ function createCurrent(service) {
 }
 
 export function createUseMachine(useEffect, useState) {
-  return function useMachine(providedMachine) {
+  return function useMachine(providedMachine, initialContext) {
     let [machine, setMachine] = useState(providedMachine);
     let [service, setService] = useState(runInterpreter);
 
-    function runInterpreter(arg) {
+    function runInterpreter(arg, data) {
       let m = arg || machine;
       return interpret(m, service => {
         setCurrent(createCurrent(service.child || service));
-      });
+      }, data || initialContext);
     }
 
     let [current, setCurrent] = useState(createCurrent(service));
@@ -30,11 +30,11 @@ export function createUseMachine(useEffect, useState) {
       if(machine !== providedMachine) {
         setMachine(providedMachine);
 
-        let newService = runInterpreter(providedMachine);
+        let newService = runInterpreter(providedMachine, initialContext);
         setService(newService);
         setCurrent(createCurrent(newService));
       }
-    }, [providedMachine]);
+    }, [providedMachine, initialContext]);
 
     return [current, service.send, service];
   };

--- a/test/test.js
+++ b/test/test.js
@@ -67,6 +67,36 @@ QUnit.module('useMachine', hooks => {
     app.remove();
   });
 
+  QUnit.test('passes along initial context', async assert => {
+    const context = initial => ({ ...initial });
+
+    const machine = createMachine({
+      solid: state()
+    }, context);
+
+    function App() {
+      const [current] = useMachine(machine, { test: 42 });
+
+      return html`
+        <span>
+          Context: ${JSON.stringify(current.context)}
+        </span>
+      `;
+    }
+
+    const Element = component(App);
+    customElements.define('initial-context', Element);
+
+    let app = new Element();
+    document.body.append(app);
+    let root = app.shadowRoot;
+
+    await later();
+
+    assert.equal(root.firstElementChild.textContent.trim(), 'Context: {"test":42}');
+    app.remove();
+  });
+
   QUnit.test('can change machines', async assert => {
     const basicMachine = (name) => createMachine({
       [name]: state()


### PR DESCRIPTION
This adds support for an initial context argument to `useMachine`.

The underlying service still only changes when the machine changes (if `useMachine` is called with a new machine).  It may also make sense to check whether the initial context has changed, but I didn't do that here.

@matthewp - let me know if you think this should be implemented in a different way.  I'm happy to make changes or add additional tests.

Fixes #8.
