### PR TITLE
Only check initialContext once

### DIFF
--- a/machine.js
+++ b/machine.js
@@ -42,7 +42,7 @@ export function createUseMachine(useEffect, useState) {
       return () => {
         mounted = false;
       }
-    }, [providedMachine, initialContext]);
+    }, [providedMachine]);
 
     return [current, service.send, service];
   };

--- a/test/test.js
+++ b/test/test.js
@@ -209,4 +209,34 @@ QUnit.module('useMachine', hooks => {
 
     assert.equal(span.textContent, 'one', 'did not change');
   });
+
+  QUnit.test('Can pass context for the initial value', async assert => {
+    let current, send;
+    let machine = createMachine({
+      one: state(
+        transition('next', 'two')
+      ),
+      two: state()
+    });
+
+    function App() {
+      const [currentState, sendEvent] = useMachine(machine, {});
+      current = currentState;
+      send = sendEvent;
+
+      return html`
+        <div>State: ${current.name}</div>
+      `;
+    }
+
+    await createSandbox(App, function* (shadow) {
+      let el = shadow.firstElementChild;
+      let text = () => el.textContent.trim();
+
+      assert.equal(text(), 'State: one');
+      yield send('next');
+
+      assert.equal(text(), 'State: two');
+    });
+  });
 });


### PR DESCRIPTION
The initialContext is only used to create the state machine, so we don't
need to use it in the effect reference. Closes #11