### PR TITLE
Fix issue when machine is updated

### DIFF
--- a/machine.js
+++ b/machine.js
@@ -31,6 +31,8 @@ export function createUseMachine(useEffect, useState) {
     let [current, setCurrent] = useState(createCurrent(service));
 
     useEffect(() => {
+      mounted = true;
+
       if(machine !== providedMachine) {
         setMachine(providedMachine);
 
@@ -47,4 +49,3 @@ export function createUseMachine(useEffect, useState) {
     return [current, service.send, service];
   };
 }
-


### PR DESCRIPTION
## Context

When `providedMachine` changes, [the effect](https://github.com/matthewp/robot-hooks/blob/master/machine.js#L33-L45) re-runs after calling the cleanup function (which sets `mounted` to `false`). `mounted` is checked whenever a transition completes (to know if it should be forwarded to the state) meaning that once the cleanup function has been called state will never be forwarded again.

It is even more relevant when using the `react-robot` library with [`Strict Mode`](https://reactjs.org/docs/strict-mode.html#ensuring-reusable-state) enabled, as stated by the [React documentation](https://reactjs.org/docs/strict-mode.html#ensuring-reusable-state:~:text=With%20Strict%20Mode%20starting%20in%20React%2018%2C%20whenever%20a%20component%20mounts%20in%20development%2C%20React%20will%20simulate%20immediately%20unmounting%20and%20remounting%20the%20component):
> With Strict Mode starting in React 18, whenever a component mounts in development, React will simulate immediately unmounting and remounting the component

## Solution

By setting `mounted` to `true` when the effect runs we ensure that `current` is properly set.